### PR TITLE
Fixing accidental integer division

### DIFF
--- a/Assets/Scripts/AI/GoblinAI.cs
+++ b/Assets/Scripts/AI/GoblinAI.cs
@@ -89,7 +89,7 @@ class GoblinAI : IStrategicAI
         int baseXp = (int)(highestExp * .6f);
         if (empire.Gold < 10000)
             empire.AddGold(10000);
-        double mapFactor = (Config.StrategicWorldSizeX + Config.StrategicWorldSizeY) / 20;
+        double mapFactor = (Config.StrategicWorldSizeX + Config.StrategicWorldSizeY) / 20f;
 
         if (State.Rand.NextDouble() < (mapFactor - empire.Armies.Count) / 10)
         {

--- a/Assets/Scripts/Entities/Army.cs
+++ b/Assets/Scripts/Entities/Army.cs
@@ -162,7 +162,7 @@ public class Army
             }
             if (unit.HasTrait(Traits.Growth) && unit.BaseScale > 1 && !unit.HasTrait(Traits.PermanentGrowth))
             {
-                float extremum = -(Config.GrowthDecayOffset - Config.GrowthDecayIncreaseRate - 1 / 2 * Config.GrowthDecayIncreaseRate);
+                float extremum = -(Config.GrowthDecayOffset - Config.GrowthDecayIncreaseRate - 1f / 2f * Config.GrowthDecayIncreaseRate);
                 if (unit.BaseScale > extremum)
                     unit.BaseScale -= extremum - (extremum * ((1 - Config.GrowthDecayOffset) - Config.GrowthDecayIncreaseRate * (extremum - 1)));     // force the decay function to be monotonous
                 else

--- a/Assets/Scripts/Entities/Spells/SpellList.cs
+++ b/Assets/Scripts/Entities/Spells/SpellList.cs
@@ -203,7 +203,7 @@ static class SpellList
             AcceptibleTargets = new List<AbilityTargets>() { AbilityTargets.Ally },
             Range = new Range(4),
             Duration = (a, t) => 3 + a.Unit.GetStat(Stat.Mind) / 10,
-            Effect = (a, t) => .3f + a.Unit.GetStat(Stat.Mind) / 1000,
+            Effect = (a, t) => .3f + a.Unit.GetStat(Stat.Mind) / 1000f,
             Type = StatusEffectType.Fast,
             Tier = 1,
             Resistable = false,
@@ -245,7 +245,7 @@ static class SpellList
             AcceptibleTargets = new List<AbilityTargets>() { AbilityTargets.Ally },
             Range = new Range(6),
             Duration = (a, t) => 2 + a.Unit.GetStat(Stat.Mind) / 10,
-            Effect = (a, t) => a.Unit.GetStat(Stat.Mind) / 4,
+            Effect = (a, t) => a.Unit.GetStat(Stat.Mind) / 4f,
             Type = StatusEffectType.Predation,
             Tier = 1,
             Resistable = false,
@@ -300,12 +300,12 @@ static class SpellList
             OnExecute = (a, t) =>
             {
                 a.CastOffensiveSpell(Pyre, t);
-                TacticalUtilities.CreateEffect(t.Position, TileEffectType.Fire, 1, 1 + a.Unit.GetStat(Stat.Mind) / 30, 4);
+                TacticalUtilities.CreateEffect(t.Position, TileEffectType.Fire, 1, 1 + a.Unit.GetStat(Stat.Mind) / 30f, 4);
             },
             OnExecuteTile = (a, l) =>
             {
                 a.CastOffensiveSpell(Pyre, null, l);
-                TacticalUtilities.CreateEffect(l, TileEffectType.Fire, 1, 1 + a.Unit.GetStat(Stat.Mind) / 30, 4);
+                TacticalUtilities.CreateEffect(l, TileEffectType.Fire, 1, 1 + a.Unit.GetStat(Stat.Mind) / 30f, 4);
             },
         };
         SpellDict[SpellTypes.Pyre] = Pyre;
@@ -340,7 +340,7 @@ static class SpellList
             AcceptibleTargets = new List<AbilityTargets>() { AbilityTargets.Enemy },
             Range = new Range(8),
             Duration = (a, t) => 4 + a.Unit.GetStat(Stat.Mind) / 5,
-            Effect = (a, t) => 1 + a.Unit.GetStat(Stat.Mind) / 20,
+            Effect = (a, t) => 1 + a.Unit.GetStat(Stat.Mind) / 20f,
             Type = StatusEffectType.Poisoned,
             Tier = 2,
             Resistable = true,
@@ -603,7 +603,7 @@ static class SpellList
             AcceptibleTargets = new List<AbilityTargets>() { AbilityTargets.Enemy, AbilityTargets.Tile },
             Range = new Range(6),
             Duration = (a, t) => 4,
-            Effect = (a, t) => 2 + a.Unit.GetStat(Stat.Mind) / 10,
+            Effect = (a, t) => 2 + a.Unit.GetStat(Stat.Mind) / 10f,
             AreaOfEffect = 1,
             Type = StatusEffectType.Poisoned,
             Tier = 0,

--- a/Assets/Scripts/Entities/Units/Actor_Unit.cs
+++ b/Assets/Scripts/Entities/Units/Actor_Unit.cs
@@ -244,7 +244,7 @@ public class Actor_Unit
         bonus += Unit.TraitBoosts.SpeedBonus;
         if (State.World?.ItemRepository != null && Unit.Items.Contains(State.World.ItemRepository.GetItem(ItemType.Shoes)))
             bonus += 1;
-        int total = Mathf.Max(bonus + 3 + ((int)Mathf.Pow(Unit.GetStat(Stat.Agility) / 4, .8f)), 1);
+        int total = Mathf.Max(bonus + 3 + ((int)Mathf.Pow(Unit.GetStat(Stat.Agility) / 4f, .8f)), 1);
         var speed = Unit.GetStatusEffect(StatusEffectType.Fast);
         if (speed != null)
         {
@@ -266,7 +266,7 @@ public class Actor_Unit
         bonus += Unit.TraitBoosts.SpeedBonus;
         if (Unit.HasTrait(Traits.Charge) && State.GameManager.TacticalMode.currentTurn <= 2)
             bonus += 4;
-        int total = Mathf.Max(bonus + 3 + ((int)Mathf.Pow(Unit.GetStat(Stat.Agility) / 4, .8f)) - sizePenalty, 1);
+        int total = Mathf.Max(bonus + 3 + ((int)Mathf.Pow(Unit.GetStat(Stat.Agility) / 4f, .8f)) - sizePenalty, 1);
         var speed = Unit.GetStatusEffect(StatusEffectType.Fast);
         if (speed != null)
         {
@@ -1421,7 +1421,7 @@ public class Actor_Unit
                     if (target.Unit.GetStatusEffect(StatusEffectType.Focus) != null)
                         target.Unit.RemoveFocus();
                     if (target.Unit.HasTrait(Traits.Toxic) && State.Rand.Next(8) == 0)
-                        Unit.ApplyStatusEffect(StatusEffectType.Poisoned, 2 + target.Unit.GetStat(Stat.Endurance) / 20, 3);
+                        Unit.ApplyStatusEffect(StatusEffectType.Poisoned, 2 + target.Unit.GetStat(Stat.Endurance) / 20f, 3);
                     if (Unit.HasTrait(Traits.ForcefulBlow))
                         TacticalUtilities.KnockBack(this, target);
                     State.GameManager.SoundManager.PlayMeleeHit(target);
@@ -1526,7 +1526,7 @@ public class Actor_Unit
                 Unit.StatusEffects.Add(new StatusEffect(StatusEffectType.Shielded, .25f, 5));
                 break;
             case 4:
-                Unit.StatusEffects.Add(new StatusEffect(StatusEffectType.Predation, Unit.GetStat(Stat.Voracity) / 4, 5));
+                Unit.StatusEffects.Add(new StatusEffect(StatusEffectType.Predation, Unit.GetStat(Stat.Voracity) / 4f, 5));
                 break;
         }
     }
@@ -1637,7 +1637,7 @@ public class Actor_Unit
                 if (Unit.HasTrait(Traits.PollenProjector) == false)
                 {
                     Unit.ApplyStatusEffect(StatusEffectType.Clumsiness, 1.5f, 3);
-                    Unit.ApplyStatusEffect(StatusEffectType.Poisoned, 2 + attacker.Unit.GetStat(Stat.Mind) / 10, 3);
+                    Unit.ApplyStatusEffect(StatusEffectType.Poisoned, 2 + attacker.Unit.GetStat(Stat.Mind) / 10f, 3);
                     Unit.ApplyStatusEffect(StatusEffectType.WillingPrey, 0, 3);
                 }
             }
@@ -2317,9 +2317,8 @@ public class Actor_Unit
         {
             return 0;
         }
-        float ratio = 0;
-        ratio = (float)((actor.Unit.GetStat(Stat.Dexterity) + actor.Unit.GetStat(Stat.Strength)) /
-            (target.Unit.GetStat(Stat.Endurance) * target.Unit.GetStat(Stat.Endurance) + target.Unit.GetStat(Stat.Will)));
+        float ratio = (actor.Unit.GetStat(Stat.Dexterity) + actor.Unit.GetStat(Stat.Strength)) /
+            (float)(target.Unit.GetStat(Stat.Endurance) * target.Unit.GetStat(Stat.Endurance) + target.Unit.GetStat(Stat.Will));
 
         if (Config.BaseCritChance > ratio)
             ratio = Config.BaseCritChance;
@@ -2335,7 +2334,7 @@ public class Actor_Unit
         }
 
         int actor_stats = (actor.Unit.GetStat(Stat.Dexterity) + actor.Unit.GetStat(Stat.Strength)) / 2;
-        float ratio = target.Unit.GetStat(Stat.Agility) / (actor_stats * actor_stats);
+        float ratio = (float)target.Unit.GetStat(Stat.Agility) / (float)(actor_stats * actor_stats);
 
         if (Config.BaseGrazeChance > ratio)
             ratio = Config.BaseGrazeChance;

--- a/Assets/Scripts/Entities/Units/PredatorComponent.cs
+++ b/Assets/Scripts/Entities/Units/PredatorComponent.cs
@@ -1465,7 +1465,7 @@ public class PredatorComponent
             if (healthReduction >= preyUnit.Unit.MaxHealth + preyUnit.Unit.Health)
                 healthReduction = preyUnit.Unit.MaxHealth + preyUnit.Unit.Health + 1;
             preyUnit.Actor.SubtractHealth(healthReduction);
-            totalHeal += Math.Max((int)(healthReduction / 2 * preyUnit.Unit.TraitBoosts.Outgoing.Nutrition * unit.TraitBoosts.Incoming.Nutrition), 1);
+            totalHeal += Math.Max((int)(healthReduction / 2f * preyUnit.Unit.TraitBoosts.Outgoing.Nutrition * unit.TraitBoosts.Incoming.Nutrition), 1);
             var baseManaGain = healthReduction * (preyUnit.Unit.TraitBoosts.Outgoing.ManaAbsorbHundreths + unit.TraitBoosts.Incoming.ManaAbsorbHundreths);
             var totalManaGain = baseManaGain / 100 + (State.Rand.Next(100) < (baseManaGain % 100) ? 1 : 0);
             unit.RestoreMana(totalManaGain);
@@ -3205,7 +3205,7 @@ public class PredatorComponent
 
     private int heatlhBoostCalc(Prey preyUnit, Actor_Unit target)
     {
-        return Mathf.RoundToInt((preyUnit.Unit.MaxHealth / 10 + (((preyUnit.Unit.MaxHealth / 10) * 9) / 20) * Math.Max(0, preyUnit.Unit.Level - target.Unit.Level / (actor.Unit.HasTrait(Traits.WetNurse) ? 2 : 1)) * preyUnit.Unit.TraitBoosts.Outgoing.Nutrition));
+        return Mathf.RoundToInt((preyUnit.Unit.MaxHealth / 10f + (((preyUnit.Unit.MaxHealth / 10f) * 9) / 20) * Math.Max(0, preyUnit.Unit.Level - target.Unit.Level / (actor.Unit.HasTrait(Traits.WetNurse) ? 2 : 1)) * preyUnit.Unit.TraitBoosts.Outgoing.Nutrition));
     }
 
     private int expBoostCalc(Prey preyUnit)

--- a/Assets/Scripts/Entities/Units/Unit.cs
+++ b/Assets/Scripts/Entities/Units/Unit.cs
@@ -1220,8 +1220,10 @@ internal void SetGenderRandomizeName(Race race, Gender gender)
     {
         if (level >= Config.HardLevelCap)
             return 99999999;
-        return (int)(expRequiredMod * level * Config.ExperiencePerLevel + ((level >= Config.SoftLevelCap ? 8 : 0) + (level * Config.AdditionalExperiencePerLevel * (level - 1) / 2)) *
-            (level >= Config.SoftLevelCap ? (int)Math.Pow(2, level + 1 - Config.SoftLevelCap) : 1));
+        
+        return Mathf.FloorToInt((expRequiredMod * level * Config.ExperiencePerLevel) +
+                                ((level >= Config.SoftLevelCap ? 8 : 0) + Mathf.FloorToInt(level * Config.AdditionalExperiencePerLevel * (level - 1) / 2f)) *
+                                (level >= Config.SoftLevelCap ? Mathf.FloorToInt(Mathf.Pow(2, level + 1 - Config.SoftLevelCap)) : 1));
     }
 
     public static int GetLevelFromExperience(int experience)
@@ -1355,12 +1357,12 @@ internal void SetGenderRandomizeName(Race race, Gender gender)
         if (stat == Stat.Mind && GetStatusEffect(StatusEffectType.Focus) != null)
         {
             int stacks = GetStatusEffect(StatusEffectType.Focus).Duration;
-            bonus += stacks + (GetStatBase(Stat.Mind) * (stacks / 100));
+            bonus += stacks + (GetStatBase(Stat.Mind) * (stacks / 100f));
         }
         if (stat == Stat.Mind && GetStatusEffect(StatusEffectType.SpellForce) != null)
         {
             int stacks = GetStatusEffect(StatusEffectType.SpellForce).Duration;
-            bonus += stacks + (GetStatBase(Stat.Mind) * (stacks/10));
+            bonus += stacks + (GetStatBase(Stat.Mind) * (stacks/10f));
         }
 
         bonus -= GetStatBase(stat) * (GetStatusEffect(StatusEffectType.Shaken)?.Strength ?? 0);


### PR DESCRIPTION
Fixed GrowthDecayIncreaseRate being multiplied by 0.

Fixed Mind scaling in SpellList being rounded down because of unintended integer division, which practically removed the scaling in some cases.

In Unit.cs
Refactored GetExperienceRequiredForLevel, behavior should be unchanged. It contained some seemingly unintended integer division and possibly unintentional rounding down. Changed to be explicit and not prone to overflow.

Fixed Mind scaling with stacks of Focus and SpellForce.

In PredatorComponent.cs fixed some unintentional integer division.

In GolbinAI.cs fixed some unintentional integer division.